### PR TITLE
Fix Jovian database install

### DIFF
--- a/jovian-databases/job/Dockerfile
+++ b/jovian-databases/job/Dockerfile
@@ -1,4 +1,5 @@
 FROM continuumio/miniconda3
-RUN apt-get update; apt-get -y install curl; apt-get -y install make
+RUN apt-get update && \
+    apt-get -y install curl libtbb2 make
 ADD install_databases.sh /install_databases.sh
 ENTRYPOINT ["bash", "install_databases.sh"]


### PR DESCRIPTION
A missing library ([`libtbb2`](https://pkgs.org/download/tbb)) caused a [bowtie2 error](http://www.metagenomics.wiki/tools/bowtie2/install/libtbb-so-2) during genome indexing. This PR adds that library.